### PR TITLE
chore(claude): add gellify.project OTel resource attribute

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "gellify.project=acme-app"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with `OTEL_RESOURCE_ATTRIBUTES=gellify.project=acme-app` so Claude Code telemetry is filterable by project in SigNoz with zero per-user configuration.
- Uses a namespaced attribute (`gellify.project`) instead of overriding `service.name`, which Claude Code reserves for `claude-code`. This preserves "all Claude Code traffic" queries while adding project-level segmentation.
- Teams forking this template change a single string (the project slug) when they adopt it.

### Why not a dynamic bash script?
The `otelHeadersHelper` mechanism populates HTTP headers, not telemetry resource attributes — those would only become queryable if the org's collector receiver extracted them. A static project-level attribute via `OTEL_RESOURCE_ATTRIBUTES` is simpler, requires no collector changes, and covers the primary need (project attribution). Repository-level joins to GitHub-receiver metrics can be added later if needed (via direnv or a wrapper).

### Why not `OTEL_SERVICE_NAME`?
Claude Code documents `service.name=claude-code` as fixed. Overriding it would conflate "which tool is emitting" with "which repo it's running in" and break canonical Claude Code queries.

## Test plan
- [x] Confirm managed settings still do **not** define `OTEL_RESOURCE_ATTRIBUTES` (otherwise this project-level value is silently dropped).
- [x] Run a Claude Code session in this repo with telemetry enabled and verify `gellify.project=acme-app` appears as a resource attribute on metrics/events in SigNoz.
- [x] Verify `service.name=claude-code` is still present and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal configuration settings to optimize application observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->