### PR TITLE
Add gellify-* Claude Code skills for API workflow and contract design

### DIFF
--- a/.claude/skills/gellify-api-contract/REFERENCE.md
+++ b/.claude/skills/gellify-api-contract/REFERENCE.md
@@ -1,0 +1,137 @@
+# REST API design rules
+
+Concise reference for designing REST contracts. Applied by `gellify-api-contract` when drafting OpenAPI specs.
+
+## Resource naming
+
+- **Nouns, not verbs.** `/orders` not `/getOrders`. The HTTP method is the verb.
+- **Plural for collections.** `/users`, `/orders`, `/audit-logs`. Item path: `/users/{id}`.
+- **Singular for singleton resources** (one-per-parent). `/users/{id}/preferences` (one preferences object per user).
+- **Lowercase, kebab-case.** `/audit-logs` not `/auditLogs` or `/audit_logs`.
+- **No file extensions** in paths.
+- **Sub-resources for ownership.** `/users/{userId}/orders` when orders belong to a user. Keep nesting shallow — max 2 levels. If you need 3, you usually want a top-level resource with a query filter.
+- **IDs are opaque** to the client. Don't expose internal numeric PKs if the entity is referenced externally; prefer UUIDs (matches the codebase's `pg_catalog.gen_random_uuid()` pattern).
+
+## HTTP methods — semantics matter
+
+| Method | Idempotent | Safe | Use for |
+|---|---|---|---|
+| `GET` | yes | yes | Read. No side effects. |
+| `POST` | no | no | Create, or actions that don't fit CRUD (e.g., `/orders/{id}/cancel`). |
+| `PUT` | yes | no | Full replacement of a resource. Client provides complete representation. |
+| `PATCH` | no* | no | Partial update. JSON Merge Patch (default) or JSON Patch (if precise ops needed). |
+| `DELETE` | yes | no | Remove. Return 204 on success. |
+
+*PATCH can be idempotent depending on payload semantics; don't rely on it.
+
+**Bulk operations**: `POST /<resource>/batch` with an array body. Don't use `PUT` for "upsert-many" — too ambiguous.
+
+**Actions that aren't CRUD**: model as sub-POST. `POST /orders/{id}/cancel`, `POST /sessions/{id}/refresh`. Don't invent verbs like `PATCH /orders/{id}?action=cancel`.
+
+## Status codes
+
+Use the smallest set that conveys meaning:
+
+| Code | Meaning | Use when |
+|---|---|---|
+| 200 OK | Success with body | GET, PATCH/PUT returning the updated resource |
+| 201 Created | Created with body | POST creating a resource (include `Location` header) |
+| 202 Accepted | Async accepted | Long-running operations |
+| 204 No Content | Success, no body | DELETE; PATCH/PUT when no body needed |
+| 400 Bad Request | Malformed request | JSON parse errors, semantic violations not caught by schema |
+| 401 Unauthorized | No/invalid auth | Missing or expired credentials |
+| 403 Forbidden | Authed but not allowed | Permission denied |
+| 404 Not Found | Resource doesn't exist | Or hidden from this caller |
+| 409 Conflict | State conflict | Duplicate unique key, version mismatch, illegal transition |
+| 422 Unprocessable | Schema validation failed | Use this for Zod/OpenAPI validation errors (matches codebase) |
+| 429 Too Many Requests | Rate limited | Include `Retry-After` |
+| 500 Internal Server Error | Server bug | Generic catch-all |
+| 503 Service Unavailable | Dependency down | Include `Retry-After` |
+
+**Don't use 200 for errors.** Don't return `{"error": "..."}` with status 200.
+
+## Pagination
+
+For list endpoints, default to **cursor pagination** when ordering is stable:
+
+```
+GET /orders?limit=20&cursor=<opaque>
+→ 200 { "data": [...], "next_cursor": "..." | null }
+```
+
+Use **offset pagination** only when the dataset is small and stable:
+
+```
+GET /orders?limit=20&offset=40
+→ 200 { "data": [...], "total": 1234 }
+```
+
+Always cap `limit` server-side (e.g., max 100). Document the default.
+
+## Filtering, sorting, searching
+
+- **Filtering**: `?status=open&priority=high`. One query param per filterable field.
+- **Sorting**: `?sort=created_at` (asc) or `?sort=-created_at` (desc). Multi-field: `?sort=-priority,created_at`.
+- **Search**: `?q=<text>` for full-text. Reserve `q` for search; don't overload it for filters.
+- **Field selection** (optional): `?fields=id,name,status`. Skip unless payload size is a real problem.
+
+## Request body conventions
+
+- **JSON only** unless there's a clear file-upload case (then `multipart/form-data`).
+- **camelCase or snake_case** — pick one project-wide. The codebase uses **camelCase in TS** but Drizzle is configured with `casing: "snake_case"` so DB columns are snake_case. For API payloads: **camelCase** (matches existing validators like `getTodosSchema`).
+- **No null vs missing ambiguity**: if absent is allowed, use `.optional()`. If null is meaningful (explicit clear), use `.nullable()`. Document the distinction.
+
+## Error response shape
+
+Match the existing codebase shape (`src/server/api/rest/utils/`). Standard envelope:
+
+```yaml
+ErrorResponse:
+  type: object
+  required: [message]
+  properties:
+    message: { type: string }
+    code: { type: string, description: "Stable machine-readable code" }
+    details: { type: object, description: "Optional structured context" }
+```
+
+For 422 (validation), use the Zod error tree shape produced by `createErrorSchema` in the codebase.
+
+## Versioning
+
+- **No version in v1.** Don't pre-emptively prefix with `/v1`. Add `/v2` only when a breaking change is actually needed.
+- When you do version: path prefix (`/v2/orders`), not header-based. Easier to debug.
+- Document deprecation: include `Deprecation` and `Sunset` response headers when an endpoint is deprecated.
+
+## Idempotency
+
+For unsafe methods that may be retried (POST creates, payment-like actions):
+- Accept `Idempotency-Key` header.
+- Server stores the response for N hours; same key → same response.
+- Document the TTL in the contract.
+
+Skip idempotency keys for trivial creates (no dedup risk).
+
+## Async / long-running
+
+- Return `202 Accepted` with `Location: /jobs/{id}` and a body containing `{ "job_id": "...", "status": "pending" }`.
+- Provide `GET /jobs/{id}` to poll.
+- Don't make the client wait synchronously.
+
+## Auth
+
+Match the existing codebase: cookie auth (`better-auth.session_token`) or API key (`x-api-key`). Declare both in `components.securitySchemes`. Per-endpoint: omit `security` to inherit; specify `security: []` to mark an endpoint as public.
+
+## Common pitfalls — avoid these
+
+- ❌ `GET /getUser?id=123` — use `GET /users/{id}`.
+- ❌ `POST /deleteOrder/{id}` — use `DELETE /orders/{id}`.
+- ❌ Mixing singular and plural across the API.
+- ❌ Returning different shapes for the same resource depending on endpoint.
+- ❌ Embedding HTML, JS, or rendered text in JSON responses.
+- ❌ 200-with-error-in-body.
+- ❌ Status code chosen "to be informative" but inconsistent (e.g., 422 for "not found"). Pick from the table above.
+
+## Sources
+
+Distilled from: RFC 9110 (HTTP semantics), RFC 7807 (problem details), Zalando RESTful API guidelines, Microsoft Azure API guidelines, Stripe API. When in doubt, look at how Stripe does it.

--- a/.claude/skills/gellify-api-contract/REFERENCE.md
+++ b/.claude/skills/gellify-api-contract/REFERENCE.md
@@ -54,14 +54,14 @@ Use the smallest set that conveys meaning:
 
 For list endpoints, default to **cursor pagination** when ordering is stable:
 
-```
+```http
 GET /orders?limit=20&cursor=<opaque>
-→ 200 { "data": [...], "next_cursor": "..." | null }
+→ 200 { "data": [...], "nextCursor": "..." | null }
 ```
 
 Use **offset pagination** only when the dataset is small and stable:
 
-```
+```http
 GET /orders?limit=20&offset=40
 → 200 { "data": [...], "total": 1234 }
 ```

--- a/.claude/skills/gellify-api-contract/SKILL.md
+++ b/.claude/skills/gellify-api-contract/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: gellify-api-contract
+description: Standalone skill. Reads an issue (Linear, GitHub, Jira, or pasted text), analyzes the problem, and produces a REST API contract as OpenAPI 3.1 YAML in docs/api/contracts/<name>.yaml. Resolves resource names against docs/GLOSSARY.md (and the existing codebase as fallback) so naming stays consistent, and updates the glossary when a new resource is introduced. Use ONLY when the user asks to design/draft/extract an API contract from an issue, ticket, PRD, or problem description — NEVER for implementation work (use gellify-app-maintenance for that).
+---
+
+# gellify-api-contract
+
+Turn an issue into a reviewable REST API contract. This skill **does not** generate code, touch routers, write services, or modify schemas. Its only side effects are:
+- `docs/api/contracts/<name>.yaml` (new OpenAPI 3.1 spec)
+- `docs/GLOSSARY.md` (append/update entries when resources are introduced)
+
+If you find yourself wanting to implement: stop and hand off to `gellify-app-maintenance` with the produced contract as input.
+
+## Workflow
+
+### 1. Fetch the issue
+
+Ask the user for the source if not specified:
+
+| Source | How to fetch |
+|---|---|
+| Linear | MCP: `mcp__claude_ai_Linear__get_issue`, `list_comments` |
+| Jira | MCP: `mcp__claude_ai_Atlassian__getJiraIssue` |
+| GitHub | `gh issue view <num> --json title,body,comments` (or GitHub MCP if available) |
+| Pasted text | Use what the user provided |
+
+Collect: title, full body, comments/replies, attached labels/types. If the issue references other issues, fetch those too (one hop is usually enough).
+
+### 2. Analyze the problem (no contract yet)
+
+Extract:
+- **Goal** — what does the caller want to accomplish? (1 sentence)
+- **Actors** — who calls this? (end user, admin, system-to-system, …)
+- **Entities** — nouns mentioned. These become resource candidates.
+- **Operations** — verbs mentioned. These map to HTTP methods.
+- **Constraints** — auth, rate limits, idempotency, async requirements, regulatory.
+- **Unknowns** — anything the issue doesn't answer that the contract needs (cardinality, pagination, error semantics, …).
+
+Surface unknowns to the user and resolve them before drafting. **Do not invent answers.**
+
+### 3. Resolve resource names — glossary-first
+
+For each candidate entity:
+
+1. **Read `docs/GLOSSARY.md`.** If the file doesn't exist, create it with the header in [templates/glossary-header.md.tmpl](templates/glossary-header.md.tmpl).
+2. If the concept exists → reuse the canonical name verbatim. Note the entry being matched.
+3. If not in glossary → **search the codebase** for similar concepts:
+   - `src/server/db/schema/*.ts` (existing tables)
+   - `src/server/domains/*/` (existing domain modules)
+   - `src/shared/validators/*.schema.ts` (existing validator naming)
+   - `src/server/api/rest/routers/*.ts` (existing URL/operation patterns)
+
+   Use Grep liberally. If a similar concept exists under a different name, prefer the existing name unless the user disagrees.
+4. If nothing matches → it's a **new resource**. Pick a name following the naming rules in [REFERENCE.md](REFERENCE.md) ("Resource naming"). Plan to append a glossary entry.
+
+Present the resource-name decisions to the user **before drafting the contract**.
+
+### 4. Draft the contract
+
+Apply [REFERENCE.md](REFERENCE.md) (REST design rules) to produce:
+- Resource paths (`/<resource>` collection, `/<resource>/{id}` item, sub-resources nested)
+- Methods (GET/POST/PUT/PATCH/DELETE) with correct semantics
+- Status codes (200/201/204 success; 400/401/403/404/409/422 client; 500/503 server)
+- Request shapes (path/query/body) and response shapes
+- Pagination, filtering, sorting where lists are returned
+- Error envelope consistent with the existing codebase pattern (see `src/server/api/rest/utils/`)
+
+Use [templates/contract.yaml.tmpl](templates/contract.yaml.tmpl) as the OpenAPI 3.1 skeleton. Fill `info`, `tags`, `paths`, `components.schemas`. Reuse `components.schemas` across endpoints — never inline duplicate schemas.
+
+### 5. Review with user
+
+Present:
+- the resource decisions and glossary diff
+- a summary table of endpoints (method, path, purpose, status codes)
+- any open question that the issue didn't resolve
+
+Iterate until the user accepts.
+
+### 6. Write files
+
+1. `docs/api/contracts/<name>.yaml` — OpenAPI 3.1 spec. `<name>` is the canonical resource (singular for single-resource specs, or the feature name for multi-resource specs).
+2. `docs/GLOSSARY.md` — append/update entries. One entry per resource and per non-obvious term.
+
+Show the user the file paths and a one-paragraph summary of what was decided. Do NOT proceed to implementation. If the user wants code, hand off with: *"Pass `docs/api/contracts/<name>.yaml` to `gellify-app-maintenance` as a contract input."*
+
+## What this skill is NOT
+
+- Not an implementer. No code, no routers, no Drizzle.
+- Not a tRPC contract designer. Output is REST-shaped (OpenAPI). The implementation skill can derive tRPC procedures from the same Zod schemas, but contract design here is REST-first.
+- Not a doc-updater for unrelated docs. Only `docs/api/contracts/` and `docs/GLOSSARY.md`.
+
+## Cross-references
+
+- [REFERENCE.md](REFERENCE.md) — REST design rules (resource naming, methods, status codes, pagination, errors, versioning)
+- [templates/contract.yaml.tmpl](templates/contract.yaml.tmpl) — OpenAPI 3.1 skeleton
+- [templates/glossary-header.md.tmpl](templates/glossary-header.md.tmpl) — bootstrap for a new `docs/GLOSSARY.md`

--- a/.claude/skills/gellify-api-contract/templates/contract.yaml.tmpl
+++ b/.claude/skills/gellify-api-contract/templates/contract.yaml.tmpl
@@ -141,7 +141,7 @@ components:
     Cursor:
       name: cursor
       in: query
-      schema: { type: string, nullable: true }
+      schema: { type: [string, "null"] }
 
   schemas:
     <Resource>:
@@ -172,8 +172,7 @@ components:
           type: array
           items: { $ref: "#/components/schemas/<Resource>" }
         nextCursor:
-          type: string
-          nullable: true
+          type: [string, "null"]
           description: Opaque cursor for the next page; null when no more pages
 
     ErrorResponse:

--- a/.claude/skills/gellify-api-contract/templates/contract.yaml.tmpl
+++ b/.claude/skills/gellify-api-contract/templates/contract.yaml.tmpl
@@ -1,0 +1,225 @@
+# OpenAPI 3.1 contract — extracted/aligned with src/server/api/rest/init.ts
+# Replace <Resource>, <resource>, <resources>, descriptions, examples.
+
+openapi: 3.1.0
+info:
+  title: "<Resource> API"
+  version: "0.1.0"
+  description: |
+    Contract for the <resource> resource.
+    Source issue: <link to Linear/GitHub/Jira issue>
+  contact:
+    name: GELLIFY Support
+    email: engineer@gellify.dev
+servers:
+  - url: /api/rest
+    description: Application API base
+
+# Security: cookie session OR api key. Per-endpoint can override.
+security:
+  - cookieAuth: []
+  - apiKeyAuth: []
+
+tags:
+  - name: <Resources>
+    description: <One-line purpose>
+
+paths:
+  /<resources>:
+    get:
+      tags: [<Resources>]
+      operationId: list<Resources>
+      summary: List <resources>
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
+        # Add filter params here, one per filterable field
+      responses:
+        "200":
+          description: Page of <resources>
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/<Resource>Page" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+        "500": { $ref: "#/components/responses/InternalError" }
+    post:
+      tags: [<Resources>]
+      operationId: create<Resource>
+      summary: Create a <resource>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/<Resource>Create" }
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/<Resource>" }
+          headers:
+            Location:
+              description: URL of the created resource
+              schema: { type: string, format: uri }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+
+  /<resources>/{id}:
+    parameters:
+      - $ref: "#/components/parameters/ResourceId"
+    get:
+      tags: [<Resources>]
+      operationId: get<Resource>ById
+      summary: Retrieve a <resource>
+      responses:
+        "200":
+          description: The <resource>
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/<Resource>" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+    patch:
+      tags: [<Resources>]
+      operationId: update<Resource>
+      summary: Update a <resource>
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/<Resource>Update" }
+      responses:
+        "200":
+          description: Updated <resource>
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/<Resource>" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+    delete:
+      tags: [<Resources>]
+      operationId: delete<Resource>
+      summary: Delete a <resource>
+      responses:
+        "204": { description: Deleted }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/ValidationError" }
+
+components:
+  securitySchemes:
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: better-auth.session_token
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+
+  parameters:
+    ResourceId:
+      name: id
+      in: path
+      required: true
+      schema: { type: string, format: uuid }
+      example: "b3b7c1e2-4c2a-4e7a-9c1a-2b7c1e24c2a4"
+    Limit:
+      name: limit
+      in: query
+      schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+    Cursor:
+      name: cursor
+      in: query
+      schema: { type: string, nullable: true }
+
+  schemas:
+    <Resource>:
+      type: object
+      required: [id, createdAt]
+      properties:
+        id: { type: string, format: uuid }
+        # ... domain fields
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    <Resource>Create:
+      type: object
+      required: []  # list required-on-create fields
+      properties:
+        # ... input fields (omit id/createdAt/updatedAt)
+
+    <Resource>Update:
+      type: object
+      properties:
+        # ... all updatable fields, all optional
+
+    <Resource>Page:
+      type: object
+      required: [data, nextCursor]
+      properties:
+        data:
+          type: array
+          items: { $ref: "#/components/schemas/<Resource>" }
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page; null when no more pages
+
+    ErrorResponse:
+      type: object
+      required: [message]
+      properties:
+        message: { type: string }
+        code: { type: string, description: "Stable machine-readable code" }
+        details: { type: object, additionalProperties: true }
+
+    ValidationErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          # Matches the Zod tree shape produced by createErrorSchema in the codebase
+
+  responses:
+    Unauthorized:
+      description: Missing or invalid credentials
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
+    Forbidden:
+      description: Authenticated but not permitted
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
+    Conflict:
+      description: State conflict (duplicate, version mismatch, illegal transition)
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorResponse" }
+    ValidationError:
+      description: Request validation failed
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ValidationErrorResponse" }
+    InternalError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/ErrorResponse" }

--- a/.claude/skills/gellify-api-contract/templates/glossary-header.md.tmpl
+++ b/.claude/skills/gellify-api-contract/templates/glossary-header.md.tmpl
@@ -1,0 +1,50 @@
+# Glossary
+
+Project-wide glossary of domain concepts, resources, and API operations. Owned by `gellify-api-contract`. Other skills (and humans) **read** this file; only `gellify-api-contract` writes new entries.
+
+## How to read this file
+
+- **Resources** — canonical names for entities exposed via APIs. Use the canonical name in code, validators, URLs, docs.
+- **Operations** — verbs the API supports on a resource (CRUD + actions).
+- **Terms** — domain concepts that aren't themselves resources but are referenced across the codebase (e.g., "session", "permission", "wide event").
+
+When adding code, search this file first before inventing a new name.
+
+## Resources
+
+<!-- Append entries below. Format:
+
+### <ResourceName>
+
+- **Path**: `/<resources>` (collection), `/<resources>/{id}` (item)
+- **Definition**: One paragraph. What it is, what it represents in the domain.
+- **Owner module**: `src/server/domains/<name>/`
+- **Operations**: list / create / read / update / delete / <custom actions>
+- **Related resources**: links to other glossary entries (`[[<OtherResource>]]`)
+- **Contract**: `docs/api/contracts/<name>.yaml`
+- **Notes**: anything non-obvious — invariants, scoping rules, soft-delete semantics.
+
+-->
+
+## Operations
+
+<!-- Standard verbs and their meaning across the codebase. Append non-standard actions here.
+
+### cancel
+
+- **Method**: POST
+- **Path shape**: `/<resources>/{id}/cancel`
+- **Definition**: Transition a resource into a terminal "cancelled" state. Idempotent on already-cancelled resources (returns 200 with current state).
+- **Used by**: <ResourceA>, <ResourceB>
+
+-->
+
+## Terms
+
+<!-- Cross-cutting concepts that aren't resources.
+
+### Wide event
+
+A canonical log line attached to every request. See `logging-best-practices` skill and `docs/logs.md`.
+
+-->

--- a/.claude/skills/gellify-api-domain-service/SKILL.md
+++ b/.claude/skills/gellify-api-domain-service/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: gellify-api-domain-service
+description: Building block invoked by gellify-app-maintenance. Creates or edits domain service files under src/server/domains/<name>/ in the acme-app — service.ts (public API consumed by routers), queries.ts (read), mutations.ts (write), helpers.ts (pure utilities). Use directly only if the user scopes the task to "just the service/business-logic layer".
+---
+
+# gellify-api-domain-service
+
+The domain layer between routers and Drizzle. Routers (tRPC + REST) consume only `<domain>-service.ts` — never `queries.ts` / `mutations.ts` directly.
+
+## File convention
+
+| File | Purpose | Example |
+|---|---|---|
+| `<domain>-service.ts` | Public functions. Composes queries + mutations + helpers. Annotated `"server-only";` | `todo-service.ts` |
+| `queries.ts` | Drizzle reads. Pure DB. `"server-only";` | `queries.ts` |
+| `mutations.ts` | Drizzle writes. Pure DB. `"server-only";` | `mutations.ts` |
+| `helpers.ts` | Pure functions (no DB). Easily unit-testable. | `helpers.ts` |
+| `<domain>-service.test.ts` | Integration tests against real DB | `todo-service.test.ts` |
+| `helpers.test.ts` | Pure unit tests | `helpers.test.ts` |
+
+## TDD workflow (use the `tdd` skill)
+
+1. **Locate** the domain folder. Edit-mode: extend existing service function. New-mode: scaffold all four files.
+2. **Test list** — service-level tests against real DB (see pattern below). Propose to user, get confirmation.
+3. **Red** → `pnpm test`.
+4. **Green** → implement query/mutation/helper + service composition.
+5. Refactor with `simplify` if helpful. `pnpm lint && pnpm typecheck`.
+
+## Test pattern (extracted from `todo-service.test.ts`)
+
+```ts
+import { beforeEach, expect, test } from "bun:test";
+import { randomUUIDv7 } from "bun";
+import { db } from "@/server/db";
+import { user as userTable } from "@/server/db/schema/auth-schema";
+
+const userId = randomUUIDv7();
+
+beforeEach(async () => {
+  await db
+    .insert(userTable)
+    .values({ id: userId, email: "test@test.com", name: "test" })
+    .onConflictDoNothing();
+});
+
+test("creates and lists", async () => {
+  // direct call to service function
+});
+```
+
+Service tests hit the real DB. No mocks. If the FK chain requires parent rows, seed them in `beforeEach` with `onConflictDoNothing`.
+
+## Templates
+
+- [templates/service.ts.tmpl](templates/service.ts.tmpl) — extracted from `todo-service.ts`
+- [templates/queries.ts.tmpl](templates/queries.ts.tmpl) — extracted from `queries.ts`
+- [templates/mutations.ts.tmpl](templates/mutations.ts.tmpl) — extracted from `mutations.ts`
+
+## Signature convention
+
+All service functions take `(db: DBClient, input: z.infer<typeof XSchema>, userId: string)` so:
+- routers pass `ctx.db` (or `c.get("db")`) and `ctx.session.user.id` (or `c.get("userId")`) directly,
+- userId scoping is explicit at the type level — easy to audit for IDOR.
+
+`queries.ts` / `mutations.ts` take their own request type that already includes `userId` — see template.
+
+## Cross-references
+
+- `tdd`
+- `engineering:write-tests`
+- `simplify` — after green
+
+## After green
+
+- Routers: invoke `gellify-api-trpc-procedure` and/or `gellify-api-rest-route` to wire the new/changed service functions in.
+- Then `gellify-docs-update`.

--- a/.claude/skills/gellify-api-domain-service/templates/mutations.ts.tmpl
+++ b/.claude/skills/gellify-api-domain-service/templates/mutations.ts.tmpl
@@ -41,6 +41,11 @@ export async function updateTodoMutation(
   // Strip the id/userId before passing to .set() — they go in WHERE, not SET.
   const { id, userId, ...rest } = params;
 
+  // Drizzle generates invalid SQL (`SET WHERE ...`) on an empty .set() — guard.
+  if (Object.keys(rest).length === 0) {
+    throw new Error("At least one field must be provided for update");
+  }
+
   const [todo] = await db
     .update(todoTable)
     .set(rest)

--- a/.claude/skills/gellify-api-domain-service/templates/mutations.ts.tmpl
+++ b/.claude/skills/gellify-api-domain-service/templates/mutations.ts.tmpl
@@ -1,0 +1,71 @@
+// Annotated template — extracted from src/server/domains/todo/mutations.ts
+// PURE DB WRITES. Drizzle only.
+"server-only";
+
+import { and, eq } from "drizzle-orm";
+
+import type { DBClient } from "@/server/db";
+import { todoTable } from "@/server/db/schema/todos";
+
+type CreateTodoParams = {
+  text: string;
+  userId: string;
+};
+
+export async function createTodoMutation(
+  db: DBClient,
+  params: CreateTodoParams,
+) {
+  // .returning() so the caller gets the row back (id, defaults, timestamps).
+  const [todo] = await db.insert(todoTable).values(params).returning();
+
+  // Throw on impossible-but-typed-as-possible empty arrays.
+  if (!todo) {
+    throw new Error("Failed to create todo");
+  }
+
+  return todo;
+}
+
+type UpdateTodoParams = {
+  id: string;
+  text?: string;
+  completed?: boolean;
+  userId: string;
+};
+
+export async function updateTodoMutation(
+  db: DBClient,
+  params: UpdateTodoParams,
+) {
+  // Strip the id/userId before passing to .set() — they go in WHERE, not SET.
+  const { id, userId, ...rest } = params;
+
+  const [todo] = await db
+    .update(todoTable)
+    .set(rest)
+    .where(and(eq(todoTable.id, id), eq(todoTable.userId, userId)))
+    .returning();
+
+  // Returns undefined if no row matched (e.g. wrong user) — caller maps to 404.
+  return todo;
+}
+
+type DeleteTodoParams = {
+  id: string;
+  userId: string;
+};
+
+export async function deleteTodoMutation(
+  db: DBClient,
+  params: DeleteTodoParams,
+) {
+  const [result] = await db
+    .delete(todoTable)
+    .where(
+      and(eq(todoTable.id, params.id), eq(todoTable.userId, params.userId)),
+    )
+    .returning();
+
+  return result;
+}

--- a/.claude/skills/gellify-api-domain-service/templates/queries.ts.tmpl
+++ b/.claude/skills/gellify-api-domain-service/templates/queries.ts.tmpl
@@ -22,7 +22,7 @@ export async function getTodosQuery(db: DBClient, filters: GetTodosRequest) {
   if (filters?.text) {
     where.push(ilike(todoTable.text, `%${filters.text}%`));
   }
-  if (filters?.completed) {
+  if (filters?.completed !== undefined && filters?.completed !== null) {
     where.push(eq(todoTable.completed, filters.completed));
   }
 

--- a/.claude/skills/gellify-api-domain-service/templates/queries.ts.tmpl
+++ b/.claude/skills/gellify-api-domain-service/templates/queries.ts.tmpl
@@ -1,0 +1,65 @@
+// Annotated template — extracted from src/server/domains/todo/queries.ts
+// PURE DB READS. Drizzle only. No mapping/aggregation — leave that for service.ts.
+"server-only";
+
+import { and, desc, eq, ilike } from "drizzle-orm";
+
+import type { DBClient } from "@/server/db";
+import { todoTable } from "@/server/db/schema/todos";
+
+// Request type INCLUDES userId — scoping is explicit at every query level.
+type GetTodosRequest = {
+  text?: string | null;
+  completed?: boolean | null;
+  userId: string;
+};
+
+export async function getTodosQuery(db: DBClient, filters: GetTodosRequest) {
+  // Always scope by userId for protected entities — first predicate in the array.
+  const where = [eq(todoTable.userId, filters.userId)];
+
+  // Optional filters: push into the array, then spread into and().
+  if (filters?.text) {
+    where.push(ilike(todoTable.text, `%${filters.text}%`));
+  }
+  if (filters?.completed) {
+    where.push(eq(todoTable.completed, filters.completed));
+  }
+
+  // Select only the columns you need — never `select().from(...)` without columns.
+  return await db
+    .select({
+      id: todoTable.id,
+      text: todoTable.text,
+      completed: todoTable.completed,
+    })
+    .from(todoTable)
+    .where(and(...where))
+    .orderBy(desc(todoTable.createdAt))
+    .limit(10);
+}
+
+type GetTodoByIdRequest = {
+  id: string;
+  userId: string;
+};
+
+export async function getTodoByIdQuery(
+  db: DBClient,
+  params: GetTodoByIdRequest,
+) {
+  const [result] = await db
+    .select({
+      id: todoTable.id,
+      text: todoTable.text,
+      completed: todoTable.completed,
+    })
+    .from(todoTable)
+    .where(
+      // Compound predicate: id AND userId — prevents IDOR.
+      and(eq(todoTable.id, params.id), eq(todoTable.userId, params.userId)),
+    )
+    .limit(1);
+
+  return result;
+}

--- a/.claude/skills/gellify-api-domain-service/templates/service.ts.tmpl
+++ b/.claude/skills/gellify-api-domain-service/templates/service.ts.tmpl
@@ -1,0 +1,67 @@
+// Annotated template — extracted from src/server/domains/todo/todo-service.ts
+// The PUBLIC API of the domain. Routers import only from this file.
+"server-only";
+
+import type z from "zod";
+import type { DBClient } from "@/server/db";
+import type {
+  // Validators define the input shape — service signatures use z.infer<typeof X>.
+  createTodoSchema,
+  getTodoByIdSchema,
+  getTodosSchema,
+  updateTodoSchema,
+} from "@/shared/validators/todo.schema";
+import { shuffleTodos } from "./helpers"; // pure helpers, easily unit-tested
+import {
+  createTodoMutation,
+  deleteTodoMutation,
+  updateTodoMutation,
+} from "./mutations";
+import { getTodoByIdQuery, getTodosQuery } from "./queries";
+
+// CONVENTION: every public function takes (db, input, userId) so callers don't
+// have to think about scoping. userId is always required for protected paths.
+
+export async function getTodos(
+  db: DBClient,
+  filters: z.infer<typeof getTodosSchema>,
+  userId: string,
+) {
+  const todos = await getTodosQuery(db, { ...filters, userId });
+
+  // The service is allowed to map/aggregate/filter after the DB call.
+  // Type safety is preserved end-to-end because queries.ts returns typed rows.
+  return shuffleTodos(todos);
+}
+
+export async function getTodoById(
+  db: DBClient,
+  filters: z.infer<typeof getTodoByIdSchema>,
+  userId: string,
+) {
+  return await getTodoByIdQuery(db, { ...filters, userId });
+}
+
+export async function createTodo(
+  db: DBClient,
+  params: z.infer<typeof createTodoSchema>,
+  userId: string,
+) {
+  return await createTodoMutation(db, { ...params, userId });
+}
+
+export async function updateTodo(
+  db: DBClient,
+  params: z.infer<typeof updateTodoSchema>,
+  userId: string,
+) {
+  return await updateTodoMutation(db, { ...params, userId });
+}
+
+export async function deleteTodo(
+  db: DBClient,
+  params: z.infer<typeof getTodoByIdSchema>,
+  userId: string,
+) {
+  return await deleteTodoMutation(db, { ...params, userId });
+}

--- a/.claude/skills/gellify-api-rest-route/SKILL.md
+++ b/.claude/skills/gellify-api-rest-route/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: gellify-api-rest-route
+description: Building block invoked by gellify-app-maintenance. Creates or edits a Hono OpenAPI route in src/server/api/rest/routers/ in the acme-app. Wires validator → service → route with required-permissions middleware, full OpenAPI response set (200/401/403/404/422/500), and Scalar docs. Use directly only if the user explicitly scopes the task to "just the REST layer".
+---
+
+# gellify-api-rest-route
+
+Add or edit a Hono OpenAPI route following the acme-app conventions.
+
+## Contract input
+
+If the orchestrator (or user) passed an OpenAPI fragment, Zod schema, or path/method/response definition, it is **authoritative**:
+- Validators MUST match the contract's request shapes (path/query/body) exactly.
+- Response schemas (`<domain>ResponseSchema`) MUST match the contract's response payload.
+- Status codes declared in the contract MUST appear in the `responses` map; the standard 401/403/422/500 set is added on top.
+- `path`, `method`, `operationId`, `tags` come from the contract when specified.
+- Tests MUST cover each declared response status.
+
+## Files involved
+
+| Path | Role |
+|---|---|
+| `src/server/api/rest/routers/<domain>-routes.ts` | route definitions |
+| `src/server/api/rest/routers/_app.ts` | mount new routers + middleware order |
+| `src/server/api/rest/init.ts` | global Hono app + OpenAPI doc + Scalar |
+| `src/server/api/rest/middleware/` | `withRequiredPermissions`, auth, db, wideEvent |
+| `src/server/api/rest/utils/` | `createRouter`, error schemas |
+| `src/shared/validators/<domain>.schema.ts` | Zod inputs (must use `@hono/zod-openapi` z) |
+| `src/server/domains/<domain>/<domain>-service.ts` | business logic |
+| `src/app/api/rest/[...rest]/route.ts` | Next.js entry — usually no edits |
+
+## TDD workflow (use the `tdd` skill)
+
+1. **Locate** files. Edit-mode: reuse router file. New-mode: create `<domain>-routes.ts` + matching test file.
+2. **Test list** — propose to user. Pattern: `src/server/api/rest/routers/todos-routes.test.ts` using `testClient` + `OpenAPIHono`. Cover:
+   - validation error → 422
+   - happy path → 200/201/204
+   - not-found → 404
+   - permission missing → 403 (if applicable)
+3. **Red** → `pnpm test` confirms failures.
+4. **Green** → implement validator + service + route.
+5. `pnpm lint && pnpm typecheck`.
+
+## Route template
+
+See [templates/route.ts.tmpl](templates/route.ts.tmpl) — annotated, extracted from `src/server/api/rest/routers/todos-routes.ts`. Covers GET-list / GET-by-id / POST / PATCH / DELETE.
+
+## Mandatory response codes
+
+Every route must declare schemas for the codes it can return. From the codebase pattern:
+
+| Code | Schema helper | When |
+|---|---|---|
+| 200/201/204 | your `<domain>ResponseSchema` | success |
+| 401 | `unauthorizedSchema()` | always |
+| 403 | `forbiddenSchema()` | when `withRequiredPermissions` is used |
+| 404 | `notFoundSchema("<entity> not found")` | when fetching by id |
+| 422 | `createErrorSchema(<inputSchema>)` | when there's path/body/query validation |
+| 500 | `internalServerErrorSchema()` | recommended on read routes |
+
+## Permissions middleware
+
+Use `withRequiredPermissions({ <resource>: ["<action>"] })`. Match the resource/action names defined in Better Auth permissions config. See `better-auth-best-practices` skill if permissions are unfamiliar.
+
+## Validator must use `@hono/zod-openapi`
+
+The schemas need `.openapi({ description, example, param })` annotations so Scalar renders the API docs. Import:
+
+```ts
+import { z } from "@hono/zod-openapi";
+```
+
+NOT plain `zod`. If the schema is shared with tRPC, this z is compatible.
+
+## Mounting (new router only)
+
+Edit `src/server/api/rest/routers/_app.ts` — note middleware order matters:
+
+```ts
+const routers = createRouter()
+  .use(...publicMiddleware)
+  .route("/health", healthRouter)           // public
+  .use(...protectedMiddleware)
+  .route("/todos", todosRouter)             // protected
+  .route("/my-new-resource", myRouter);     // protected
+```
+
+## Cross-references
+
+- `tdd` skill
+- `engineering:write-tests`
+- `logging-best-practices` — `c.set("wideEvent", ...)` or `c.get("wideEvent")` enrichment
+- `better-auth-best-practices` — permissions config
+- `next-best-practices` — App Router route handler behavior
+
+## After green
+
+- `gellify-docs-update` — the Scalar UI updates automatically from the OpenAPI doc; markdown docs and ADR (if needed) still required.

--- a/.claude/skills/gellify-api-rest-route/templates/route.ts.tmpl
+++ b/.claude/skills/gellify-api-rest-route/templates/route.ts.tmpl
@@ -53,6 +53,7 @@ export const todosRouter = createRouter()
         },
         401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
         403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        422: { description: "The validation error(s)", content: { "application/json": { schema: createErrorSchema(getTodosSchema) } } },
         500: { description: "Internal Server Error", content: { "application/json": { schema: internalServerErrorSchema() } } },
       },
       middleware: [withRequiredPermissions({ todo: ["list"] })],

--- a/.claude/skills/gellify-api-rest-route/templates/route.ts.tmpl
+++ b/.claude/skills/gellify-api-rest-route/templates/route.ts.tmpl
@@ -1,0 +1,208 @@
+// Annotated template — extracted from src/server/api/rest/routers/todos-routes.ts
+// Replace <Domain>, <domain>, paths, and tags.
+
+import { createRoute } from "@hono/zod-openapi";
+import {
+  createTodo,
+  deleteTodo,
+  getTodoById,
+  getTodos,
+  updateTodo,
+} from "@/server/domains/todo/todo-service";
+import {
+  // Validators MUST come from a schema file using `@hono/zod-openapi` z.
+  createTodoSchema,
+  getTodoByIdSchema,
+  getTodosSchema,
+  todoResponseSchema,
+  todosResponseSchema,
+  updateTodoSchema,
+} from "@/shared/validators/todo.schema";
+import { withRequiredPermissions } from "../middleware/required-permissions";
+import { createErrorSchema } from "../utils/create-error-schema";
+import { createRouter } from "../utils/create-router";
+import {
+  forbiddenSchema,
+  internalServerErrorSchema,
+  notFoundSchema,
+  unauthorizedSchema,
+} from "../utils/not-found-schema";
+
+// Tags group routes in Scalar docs.
+const tags = ["Todos"];
+
+export const todosRouter = createRouter()
+  // ------------------------------------------------------------------
+  // GET / — list
+  // ------------------------------------------------------------------
+  .openapi(
+    createRoute({
+      method: "get",
+      path: "/",
+      summary: "List all todos",
+      operationId: "listTodos", // unique across the app
+      description: "Retrieve a list of todos.",
+      tags,
+      request: {
+        query: getTodosSchema, // .openapi() annotations on each field
+      },
+      responses: {
+        200: {
+          description: "The list of todos",
+          content: { "application/json": { schema: todosResponseSchema } },
+        },
+        401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
+        403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        500: { description: "Internal Server Error", content: { "application/json": { schema: internalServerErrorSchema() } } },
+      },
+      middleware: [withRequiredPermissions({ todo: ["list"] })],
+    }),
+    async (ctx) => {
+      const db = ctx.get("db");
+      const userId = ctx.get("userId");
+      const filters = ctx.req.valid("query");
+
+      const result = await getTodos(db, filters, userId);
+
+      // Optionally enrich wideEvent here:
+      // ctx.get("wideEvent").todos = { todo_count: result.length };
+
+      return ctx.json(result, 200);
+    },
+  )
+
+  // ------------------------------------------------------------------
+  // GET /{id} — by id
+  // ------------------------------------------------------------------
+  .openapi(
+    createRoute({
+      method: "get",
+      path: "/{id}",
+      summary: "Retrieve a todo",
+      operationId: "getTodoById",
+      description: "Retrieve a todo by ID.",
+      tags,
+      request: { params: getTodoByIdSchema },
+      responses: {
+        200: { description: "Retrieve a todo by ID.", content: { "application/json": { schema: todoResponseSchema } } },
+        401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
+        403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        404: { description: "Todo not found", content: { "application/json": { schema: notFoundSchema() } } },
+        422: { description: "The validation error(s)", content: { "application/json": { schema: createErrorSchema(getTodoByIdSchema) } } },
+      },
+      middleware: [withRequiredPermissions({ todo: ["list"] })],
+    }),
+    async (c) => {
+      const db = c.get("db");
+      const userId = c.get("userId");
+      const id = c.req.valid("param").id;
+
+      const result = await getTodoById(db, { id }, userId);
+      if (!result) return c.json({ message: "Todo not found" }, 404);
+
+      return c.json(result, 200);
+    },
+  )
+
+  // ------------------------------------------------------------------
+  // POST / — create
+  // ------------------------------------------------------------------
+  .openapi(
+    createRoute({
+      method: "post",
+      path: "/",
+      summary: "Create a new todo",
+      operationId: "createTodo",
+      description: "Create a new todo.",
+      tags,
+      request: {
+        body: { content: { "application/json": { schema: createTodoSchema } }, required: true },
+      },
+      responses: {
+        201: { description: "Todo created", content: { "application/json": { schema: todoResponseSchema } } },
+        401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
+        403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        422: { description: "The validation error(s)", content: { "application/json": { schema: createErrorSchema(createTodoSchema) } } },
+      },
+      middleware: [withRequiredPermissions({ todo: ["create"] })],
+    }),
+    async (c) => {
+      const db = c.get("db");
+      const userId = c.get("userId");
+      const body = c.req.valid("json");
+
+      const result = await createTodo(db, { ...body }, userId);
+      return c.json(result, 201);
+    },
+  )
+
+  // ------------------------------------------------------------------
+  // PATCH /{id} — update
+  // ------------------------------------------------------------------
+  .openapi(
+    createRoute({
+      method: "patch",
+      path: "/{id}",
+      summary: "Update a todo",
+      operationId: "updateTodo",
+      description: "Update a todo by ID.",
+      tags,
+      request: {
+        params: getTodoByIdSchema,
+        // omit the id from the body schema since it comes from path.
+        body: { content: { "application/json": { schema: updateTodoSchema.omit({ id: true }) } } },
+      },
+      responses: {
+        200: { description: "Todo updated", content: { "application/json": { schema: todoResponseSchema } } },
+        401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
+        403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        404: { description: "Not found error", content: { "application/json": { schema: notFoundSchema("Todo not found") } } },
+        422: { description: "The validation error(s)", content: { "application/json": { schema: createErrorSchema(updateTodoSchema) } } },
+      },
+      middleware: [withRequiredPermissions({ todo: ["update"] })],
+    }),
+    async (c) => {
+      const db = c.get("db");
+      const userId = c.get("userId");
+      const { id } = c.req.valid("param");
+      const params = c.req.valid("json");
+
+      const result = await updateTodo(db, { ...params, id }, userId);
+      if (!result) return c.json({ message: "Not found" }, 404);
+
+      return c.json(result, 200);
+    },
+  )
+
+  // ------------------------------------------------------------------
+  // DELETE /{id}
+  // ------------------------------------------------------------------
+  .openapi(
+    createRoute({
+      method: "delete",
+      path: "/{id}",
+      summary: "Delete a todo",
+      operationId: "deleteTodo",
+      description: "Delete a todo by ID.",
+      tags,
+      request: { params: getTodoByIdSchema },
+      responses: {
+        204: { description: "Todo deleted" },
+        401: { description: "Unauthorized", content: { "application/json": { schema: unauthorizedSchema() } } },
+        403: { description: "Forbidden", content: { "application/json": { schema: forbiddenSchema() } } },
+        404: { description: "Todo not found", content: { "application/json": { schema: notFoundSchema() } } },
+        422: { description: "The validation error(s)", content: { "application/json": { schema: createErrorSchema(getTodoByIdSchema) } } },
+      },
+      middleware: [withRequiredPermissions({ todo: ["delete"] })],
+    }),
+    async (c) => {
+      const db = c.get("db");
+      const userId = c.get("userId");
+      const id = c.req.valid("param").id;
+
+      const deleted = await deleteTodo(db, { id }, userId);
+      if (!deleted) return c.json({ message: "Todo not found" }, 404);
+
+      return c.body(null, 204);
+    },
+  );

--- a/.claude/skills/gellify-api-trpc-procedure/SKILL.md
+++ b/.claude/skills/gellify-api-trpc-procedure/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: gellify-api-trpc-procedure
+description: Building block invoked by gellify-app-maintenance. Creates or edits a tRPC procedure in src/server/api/trpc/routers/ in the acme-app. Wires validator → service → procedure with auth/permissions and wideEvent enrichment. Use directly only if the user explicitly scopes the task to "just the tRPC layer". Otherwise prefer gellify-app-maintenance.
+---
+
+# gellify-api-trpc-procedure
+
+Add or edit a tRPC procedure following the acme-app conventions.
+
+## Contract input
+
+If the orchestrator (or user) passed an interface contract (Zod, TS type, OpenAPI fragment, tRPC signature), it is **authoritative**:
+- The validator in `src/shared/validators/<domain>.schema.ts` MUST match the contract field-for-field.
+- The procedure return shape MUST match the contract's output type.
+- If the contract is partial (e.g., only inputs given), still match what's given exactly; ask before inventing the rest.
+- Tests in the test list MUST cover every required field and every documented error case from the contract.
+
+## Files involved
+
+| Path | Role |
+|---|---|
+| `src/server/api/trpc/routers/<domain>.ts` | router with procedures |
+| `src/server/api/trpc/routers/_app.ts` | mount new routers here |
+| `src/server/api/trpc/init.ts` | `publicProcedure` / `protectedProcedure` / `adminProcedure` |
+| `src/shared/validators/<domain>.schema.ts` | Zod inputs (use `@hono/zod-openapi` z when also exposed via REST) |
+| `src/server/domains/<domain>/<domain>-service.ts` | business logic |
+
+## TDD workflow (use the `tdd` skill)
+
+1. **Locate** existing files. Edit-mode: reuse the existing router, validator, service. New-mode: create them.
+2. **Test list** — propose to user, get confirmation. Pattern: `src/server/domains/<domain>/<domain>-service.test.ts` (service-level) — tRPC procedures are typically tested via service tests; only add a router test if the procedure has non-trivial branching beyond what the service tests cover. Use `createCaller` from `_app.ts` for direct router tests.
+3. **Red** → `pnpm test` confirms failures.
+4. **Green** → implement validator + service + procedure.
+5. `pnpm lint && pnpm typecheck`.
+
+## Procedure template
+
+See [templates/router.ts.tmpl](templates/router.ts.tmpl) — annotated, extracted from `src/server/api/trpc/routers/todo.ts`.
+
+## Pick the right procedure base
+
+- **`publicProcedure`** — unauthenticated. Health, public read-only.
+- **`protectedProcedure`** — most common. Auth required; `ctx.session.user.id` available.
+- **`adminProcedure`** — admin role required.
+
+## wideEvent enrichment
+
+Every procedure should attach business context to `ctx.wideEvent` for canonical log lines. See `logging-best-practices` skill. Pattern:
+
+```ts
+.query(async ({ ctx: { db, session, wideEvent }, input }) => {
+  const res = await getTodos(db, input, session.user.id);
+  wideEvent.todos = { todo_count: res.length };
+  return res;
+})
+```
+
+## Mounting (new router only)
+
+Edit `src/server/api/trpc/routers/_app.ts`:
+
+```ts
+import { myRouter } from "./my";
+export const appRouter = createTRPCRouter({
+  // ...existing
+  my: myRouter,
+});
+```
+
+## Cross-references
+
+- `tdd` skill — red-green-refactor
+- `engineering:write-tests` — test conventions
+- `logging-best-practices` — `wideEvent` structure
+- `better-auth-best-practices` — when auth/permissions change
+- `node_modules/@trpc/server/skills/server-setup/SKILL.md` — router fundamentals
+- `node_modules/@trpc/server/skills/auth/SKILL.md` — when changing auth procedures
+- `node_modules/@trpc/server/skills/validators/SKILL.md` — input/output validators
+- `node_modules/@trpc/server/skills/middlewares/SKILL.md` — middleware composition
+
+## After green
+
+- Hand back to `gellify-app-maintenance` (or invoke directly): `gellify-docs-update`.

--- a/.claude/skills/gellify-api-trpc-procedure/templates/router.ts.tmpl
+++ b/.claude/skills/gellify-api-trpc-procedure/templates/router.ts.tmpl
@@ -1,0 +1,63 @@
+// Annotated template — extracted from src/server/api/trpc/routers/todo.ts
+// Replace <Domain>, <domain>, and procedure names. Keep imports tidy.
+
+import {
+  // Service functions live in src/server/domains/<domain>/<domain>-service.ts
+  createTodo,
+  deleteTodo,
+  getTodos,
+  updateTodo,
+} from "@/server/domains/todo/todo-service";
+import {
+  // Zod schemas live in src/shared/validators/<domain>.schema.ts
+  // Use `@hono/zod-openapi` z if the schema is shared with REST.
+  createTodoSchema,
+  getTodoByIdSchema,
+  getTodosSchema,
+  updateTodoSchema,
+} from "@/shared/validators/todo.schema";
+import { createTRPCRouter, protectedProcedure } from "../init";
+
+export const todoRouter = createTRPCRouter({
+  // QUERY — reads data. Use .query().
+  get: protectedProcedure
+    .input(getTodosSchema) // Zod validator — same one used by REST when shared.
+    .query(async ({ ctx: { db, session, wideEvent }, input }) => {
+      const res = await getTodos(db, input, session.user.id);
+
+      // wideEvent: canonical log line context (see `logging-best-practices` skill).
+      // Use stable keys grouped under a domain namespace.
+      wideEvent.todos = {
+        todo_count: res.length,
+      };
+
+      return res;
+    }),
+
+  // MUTATION — writes data. Use .mutation().
+  create: protectedProcedure
+    .input(createTodoSchema)
+    .mutation(async ({ ctx: { db, session, wideEvent }, input }) => {
+      const res = await createTodo(db, input, session.user.id);
+
+      // Attach the new resource id so the canonical log has it.
+      wideEvent.todo = {
+        todo_id: res.id,
+      };
+
+      return res;
+    }),
+
+  update: protectedProcedure
+    .input(updateTodoSchema)
+    .mutation(async ({ ctx: { db, session }, input }) => {
+      // wideEvent not strictly required, but recommended for write paths.
+      return await updateTodo(db, input, session.user.id);
+    }),
+
+  delete: protectedProcedure
+    .input(getTodoByIdSchema)
+    .mutation(async ({ ctx: { db, session }, input }) => {
+      return await deleteTodo(db, input, session.user.id);
+    }),
+});

--- a/.claude/skills/gellify-app-maintenance/DISPATCH.md
+++ b/.claude/skills/gellify-app-maintenance/DISPATCH.md
@@ -1,0 +1,76 @@
+# DISPATCH — how to classify requests and pick layers
+
+## Classification
+
+| Phrase pattern | Class | Notes |
+|---|---|---|
+| "add a new endpoint/procedure", "create an API for X", "expose Y" | **New endpoint** | Plan: validator + service + router (+ DB if new entity) |
+| "the X API should also do Y", "change the X logic to ...", "add field Z to the X endpoint" | **Edit existing** | Locate first; touch only what's needed |
+| "rename X to Y", "deprecate X", "version v2 of X", "remove X" | **Contract change** | Go through [PLAYBOOKS.md](PLAYBOOKS.md). Caller-visible. |
+
+## Surface (tRPC vs REST)
+
+| Signal | Pick |
+|---|---|
+| User said "tRPC" / "procedure" / mentions `src/server/api/trpc` | tRPC |
+| User said "REST" / "OpenAPI" / "public API" / mentions `src/app/api/rest` | REST |
+| Domain has only one surface | match it |
+| Domain has both surfaces (e.g. `todo`) | ask once, default to both |
+
+## Layer matrix — examples extracted from the codebase
+
+### Example 1 — "create-user API: check CF uniqueness, add SPID relation"
+
+| Layer | Touch | Why |
+|---|---|---|
+| DB schema | yes | new `spid` field/table + relation on `user` |
+| Migration | yes | DB shape changed |
+| Validator (`user.schema.ts`) | yes | new input field |
+| Service (`domains/auth/` or `domains/user/`) | yes | `assertCfUnique()` + `createUser` extension |
+| tRPC router (`routers/user.ts`) | yes | wire input + error mapping |
+| REST router | if exists for user | mirror tRPC |
+| Docs | yes | document new field + uniqueness rule |
+| ADR | **yes** | new domain concept (SPID) — architecturally meaningful |
+
+Test list:
+- service: `creates user with valid CF + SPID`, `rejects duplicate CF with domain error`, `persists SPID relation`
+- validator: `rejects malformed SPID`, `rejects missing CF`
+- router (tRPC): `maps duplicate-CF error to TRPCError CONFLICT`
+- router (REST): `returns 409 on duplicate CF`, `returns 422 on malformed SPID`
+
+### Example 2 — "read-user API: only return active users"
+
+| Layer | Touch | Why |
+|---|---|---|
+| DB schema | no | `active` column already exists |
+| Migration | no | — |
+| Validator | no | input unchanged |
+| Service | **yes** | add `where(eq(user.active, true))` in `getUser` query |
+| Router | no | signature unchanged |
+| Docs | yes | short note: "returns active users only" |
+| ADR | no | internal logic change, not architectural |
+
+Test list:
+- service: `returns active user`, `does not return inactive user`, `returns empty when only inactive users match`
+
+### Example 3 — "add `completed` filter default = false to listTodos"
+
+| Layer | Touch | Why |
+|---|---|---|
+| Validator | yes | default value in `getTodosSchema` |
+| Service / query | yes | apply default if unspecified |
+| Router | no | input/output shape unchanged |
+| Docs | yes | document default |
+| ADR | no | |
+
+## When tests touch infrastructure
+
+If a service test needs a user row (FK), follow the pattern in `src/server/domains/todo/todo-service.test.ts`:
+
+```ts
+beforeEach(async () => {
+  await db.insert(userTable).values({ id: userId, email: "...", name: "..." }).onConflictDoNothing();
+});
+```
+
+For REST route tests, use `testClient` + `OpenAPIHono` with middleware seeded with `db`, `userId`, `permissions` — pattern in `src/server/api/rest/routers/todos-routes.test.ts`.

--- a/.claude/skills/gellify-app-maintenance/PLAYBOOKS.md
+++ b/.claude/skills/gellify-app-maintenance/PLAYBOOKS.md
@@ -1,0 +1,47 @@
+# PLAYBOOKS — contract changes
+
+These apply when the change is **caller-visible**: rename, deprecate, version, remove, intentional break.
+
+## When ADR (always check)
+
+Write an ADR via `gellify-docs-update` when any of:
+- introduces a new domain concept or entity (e.g., SPID)
+- changes an irreversible architectural decision (auth scheme, transport, error model)
+- adopts/drops a dependency
+- changes a project-wide pattern (e.g., switching from service files to use-cases)
+- locks in a contract decision callers depend on (versioning policy, deprecation window)
+
+Skip ADR for: bugfixes, internal refactors, validator tweaks that don't change semantics, doc-only changes.
+
+## Rename a procedure or route
+
+1. **Decide window**: keep both names working for N releases, or hard cut? Ask user.
+2. Add the new name; have it delegate to the existing implementation.
+3. Mark the old name `@deprecated` with JSDoc pointing to the new name.
+4. Update **all in-repo callers** (Grep for the old name across `src/`).
+5. Tests: keep tests for old name (asserting it still works) + duplicate for new name. Both green.
+6. Docs: changelog entry + deprecation notice.
+7. ADR if this is a pattern (e.g., "we're standardizing on noun.verb naming") — otherwise skip.
+
+## Deprecate
+
+1. Mark `@deprecated` with JSDoc: reason + replacement + removal date.
+2. Emit a `wideEvent` warning when the deprecated path is hit (helps drive callers off it).
+3. Update docs with deprecation table.
+4. Do NOT remove yet — schedule removal via a follow-up.
+
+## Version (v2)
+
+1. New file: `routers/<domain>-v2.ts` (REST) or `<domain>V2` sub-router (tRPC).
+2. Mount under `/v2/...` (REST) or `<domain>V2` namespace (tRPC).
+3. Share the service layer unless behavior diverges; if it diverges, create `<service>-v2.ts`.
+4. v1 stays untouched and passing.
+5. ADR: **required** — versioning policy is architectural.
+
+## Break (intentional)
+
+1. Confirm with user: any external callers? If yes, push toward version-bump instead.
+2. Update validator, service, router atomically.
+3. Update all in-repo callers.
+4. CHANGELOG: prominent BREAKING entry.
+5. ADR: **required**.

--- a/.claude/skills/gellify-app-maintenance/SKILL.md
+++ b/.claude/skills/gellify-app-maintenance/SKILL.md
@@ -12,7 +12,7 @@ Central orchestrator. The user describes a change in natural language; this skil
 ### 1. Intake & analysis (no code)
 
 1. Read the request. Locate every affected file using Grep/Glob — table in `src/server/db/schema/`, validator in `src/shared/validators/`, service in `src/server/domains/<name>/`, router in `src/server/api/trpc/routers/` and/or `src/server/api/rest/routers/`.
-1a. **Check for an input contract.** If the user pasted/attached any of:
+2. **Check for an input contract.** If the user pasted/attached any of:
    - OpenAPI / JSON Schema fragment
    - Zod schema snippet
    - tRPC procedure signature
@@ -21,11 +21,11 @@ Central orchestrator. The user describes a change in natural language; this skil
    - TypeScript interface / type alias describing inputs or outputs
 
    → treat it as **authoritative**. Do not invent field names, types, or response shapes that contradict it. If the contract is ambiguous or partial, ask the user to fill the gap rather than guessing. Pass the contract verbatim to the relevant building block in the dispatch step.
-2. Classify the change using [DISPATCH.md](DISPATCH.md):
+3. Classify the change using [DISPATCH.md](DISPATCH.md):
    - **New endpoint** / **Edit existing** / **Contract change (rename/deprecate/version/break)**
    - tRPC, REST, or **both** (if both surfaces exist for the domain, change both unless user says otherwise)
-3. If the surface is unclear AND the user didn't specify, ask **once**: *"tRPC procedure, REST endpoint, or both?"* Default: whatever already exists for that domain.
-4. Build a **layer plan**:
+4. If the surface is unclear AND the user didn't specify, ask **once**: *"tRPC procedure, REST endpoint, or both?"* Default: whatever already exists for that domain.
+5. Build a **layer plan**:
 
    | Layer | Touch? | Sub-skill |
    |---|---|---|
@@ -37,7 +37,7 @@ Central orchestrator. The user describes a change in natural language; this skil
    | REST router | y/n | `gellify-api-rest-route` |
    | Docs / ADR | always | `gellify-docs-update` |
 
-5. Draft a **test list** — concrete `describe/it` names per affected layer (happy path, validation, auth/permission, edge cases). Pattern: see `src/server/domains/todo/todo-service.test.ts` and `src/server/api/rest/routers/todos-routes.test.ts`.
+6. Draft a **test list** — concrete `describe/it` names per affected layer (happy path, validation, auth/permission, edge cases). Pattern: see `src/server/domains/todo/todo-service.test.ts` and `src/server/api/rest/routers/todos-routes.test.ts`.
 
 ### 2. Confirmation gate (blocking)
 
@@ -50,10 +50,12 @@ Ask: *"Accept the plan and test list, edit them, or supply your own test cases?"
 
 ### 3. TDD dispatch loop
 
-For each layer in dependency order (DB → migration → service → validator → router):
+For each layer in dependency order (DB → migration → validator → service → router):
+
+> Validator before service: domain service signatures are typed from validator schemas (`z.infer<typeof ...Schema>`), so the Zod schema must exist before the service layer compiles.
 
 1. Invoke the matching sub-skill.
-2. **Red first**: write failing tests using `bun test` conventions (`bun:test` imports, see existing tests). Run `pnpm test` — confirm red.
+2. **Red first**: write failing tests using `bun:test` imports (see existing tests). Run `pnpm test` (the script invokes `bun test`) — confirm red.
 3. **Green**: implement until green.
 4. Run `pnpm lint` and `pnpm typecheck`.
 5. (Optional) Invoke `simplify` skill on changed files.

--- a/.claude/skills/gellify-app-maintenance/SKILL.md
+++ b/.claude/skills/gellify-app-maintenance/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gellify-app-maintenance
+description: Single entry point for ANY change to the acme-app (GELLIFY Stack — Next.js + tRPC + Hono + Drizzle + Better Auth). Analyzes the user's request, plans the layers touched (DB → migration → service → router → docs), and dispatches to the right building-block skills with a TDD-first loop. Use when the user wants to create, evolve, edit, rename, deprecate, or version any API, business logic, database table, or domain service. Triggers: "add/change/edit/update/create/remove ... API/endpoint/procedure/route/field/table/migration/service".
+---
+
+# gellify-app-maintenance
+
+Central orchestrator. The user describes a change in natural language; this skill **plans, confirms, dispatches, and finalises with docs**. Sub-skills (`gellify-api-*`, `gellify-db-*`, `gellify-docs-update`) are building blocks — do not invoke them directly unless this skill says to.
+
+## Three phases
+
+### 1. Intake & analysis (no code)
+
+1. Read the request. Locate every affected file using Grep/Glob — table in `src/server/db/schema/`, validator in `src/shared/validators/`, service in `src/server/domains/<name>/`, router in `src/server/api/trpc/routers/` and/or `src/server/api/rest/routers/`.
+1a. **Check for an input contract.** If the user pasted/attached any of:
+   - OpenAPI / JSON Schema fragment
+   - Zod schema snippet
+   - tRPC procedure signature
+   - SQL DDL (`CREATE TABLE ...`)
+   - Drizzle table snippet
+   - TypeScript interface / type alias describing inputs or outputs
+
+   → treat it as **authoritative**. Do not invent field names, types, or response shapes that contradict it. If the contract is ambiguous or partial, ask the user to fill the gap rather than guessing. Pass the contract verbatim to the relevant building block in the dispatch step.
+2. Classify the change using [DISPATCH.md](DISPATCH.md):
+   - **New endpoint** / **Edit existing** / **Contract change (rename/deprecate/version/break)**
+   - tRPC, REST, or **both** (if both surfaces exist for the domain, change both unless user says otherwise)
+3. If the surface is unclear AND the user didn't specify, ask **once**: *"tRPC procedure, REST endpoint, or both?"* Default: whatever already exists for that domain.
+4. Build a **layer plan**:
+
+   | Layer | Touch? | Sub-skill |
+   |---|---|---|
+   | DB schema (`src/server/db/schema/`) | y/n | `gellify-db-schema` |
+   | Migration (`drizzle-kit generate`) | y/n | `gellify-db-migration` |
+   | Validator (`src/shared/validators/`) | y/n | inline in this skill |
+   | Domain service (`src/server/domains/<name>/`) | y/n | `gellify-api-domain-service` |
+   | tRPC router | y/n | `gellify-api-trpc-procedure` |
+   | REST router | y/n | `gellify-api-rest-route` |
+   | Docs / ADR | always | `gellify-docs-update` |
+
+5. Draft a **test list** — concrete `describe/it` names per affected layer (happy path, validation, auth/permission, edge cases). Pattern: see `src/server/domains/todo/todo-service.test.ts` and `src/server/api/rest/routers/todos-routes.test.ts`.
+
+### 2. Confirmation gate (blocking)
+
+Present to user:
+- the file-level plan
+- the test list
+- whether an ADR is recommended (see [PLAYBOOKS.md](PLAYBOOKS.md) → "When ADR")
+
+Ask: *"Accept the plan and test list, edit them, or supply your own test cases?"* **Do not proceed without explicit acceptance.**
+
+### 3. TDD dispatch loop
+
+For each layer in dependency order (DB → migration → service → validator → router):
+
+1. Invoke the matching sub-skill.
+2. **Red first**: write failing tests using `bun test` conventions (`bun:test` imports, see existing tests). Run `pnpm test` — confirm red.
+3. **Green**: implement until green.
+4. Run `pnpm lint` and `pnpm typecheck`.
+5. (Optional) Invoke `simplify` skill on changed files.
+
+Always end with `gellify-docs-update`. ADR if the change matches the triggers in PLAYBOOKS.md.
+
+## Cross-skill references
+
+- TDD loop details → use the **`tdd`** skill (don't redefine it here)
+- Test conventions → **`engineering:write-tests`**
+- `wideEvent` enrichment → **`logging-best-practices`** (procedures expose `ctx.wideEvent`, REST routes use `c.set("wideEvent", ...)`)
+- Auth/permissions changes → **`better-auth-best-practices`**
+- Route handler / Next.js concerns → **`next-best-practices`**
+- tRPC internals → `node_modules/@trpc/server/skills/{server-setup,auth,middlewares,validators}/SKILL.md`
+
+## See also
+
+- [DISPATCH.md](DISPATCH.md) — decision tables and worked examples
+- [PLAYBOOKS.md](PLAYBOOKS.md) — rename / deprecate / version / break

--- a/.claude/skills/gellify-db-migration/SKILL.md
+++ b/.claude/skills/gellify-db-migration/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gellify-db-migration
+description: Building block invoked by gellify-app-maintenance. Generates, reviews, applies, and (when needed) rolls back Drizzle migrations for the acme-app. Wraps drizzle-kit commands (db:generate, db:migrate, db:push, db:studio) and enforces a destructive-change review step. Use directly only if the user scopes the task to "just migrations".
+---
+
+# gellify-db-migration
+
+Generate and apply Drizzle migrations from `src/server/db/schema/`.
+
+## Commands (from package.json)
+
+| Command | Use when |
+|---|---|
+| `pnpm db:generate` | Schema changed → emit SQL migration file in `src/server/db/migrations/` |
+| `pnpm db:migrate` | Apply pending migration files to the configured DB |
+| `pnpm db:push` | Dev-only: push schema directly without a migration file. **Never use against prod-like DBs.** |
+| `pnpm db:studio` | Browse the DB |
+| `pnpm db:seed` | Run `src/server/db/seed.ts` |
+
+## Workflow
+
+1. After `gellify-db-schema` finishes editing schema files, run `pnpm db:generate`.
+2. **Inspect the generated `.sql`** before doing anything else. Look for:
+   - `DROP COLUMN` / `DROP TABLE` — confirm with user before proceeding
+   - `ALTER COLUMN ... SET NOT NULL` on a populated column — risk of failure; needs backfill
+   - renames that drizzle-kit detected as drop+create — verify intent
+3. If anything in (2) trips: pause, present the diff and a safer plan to the user.
+4. Apply: `pnpm db:migrate`.
+5. Re-run service tests (`pnpm test`) to confirm green against the new schema.
+6. Update `seed.ts` if new tables need seed data.
+
+## Destructive-change protocol
+
+Drizzle migrations are forward-only by default. Before applying any of:
+- column drop
+- table drop
+- type narrowing (varchar(256) → varchar(64))
+- NOT NULL on existing nullable column without default
+- unique constraint on existing data
+
+→ Confirm with user. Offer a **two-step** alternative when feasible: deploy code that tolerates both shapes, migrate data, then deploy the destructive migration.
+
+## Rollback
+
+There's no built-in `down`. To revert:
+1. Manually craft a reverse `.sql`, or
+2. Edit schema back to previous state + `pnpm db:generate` to produce the inverse migration.
+
+Either way: review carefully before applying.
+
+## Cross-references
+
+- `gellify-db-schema` — the previous step in the chain
+- `gellify-api-domain-service` — queries/mutations may need updates to match new columns

--- a/.claude/skills/gellify-db-schema/SKILL.md
+++ b/.claude/skills/gellify-db-schema/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: gellify-db-schema
+description: Building block invoked by gellify-app-maintenance. Adds or modifies a Drizzle table in src/server/db/schema/ for the acme-app (PostgreSQL, snake_case casing, `acme_` table prefix). Defines columns, relations, indexes, and the `DB_*Type`/`DB_*InsertType` exports. Use directly only if the user scopes the task to "just the schema". Always pair with gellify-db-migration to generate the SQL migration.
+---
+
+# gellify-db-schema
+
+Add or modify a Drizzle table.
+
+## Contract input
+
+If the orchestrator (or user) passed a schema contract — SQL DDL (`CREATE TABLE ...`), an existing Drizzle table snippet, a TS interface for the row, or a JSON Schema for the entity — it is **authoritative**:
+- Column names, types, nullability, defaults, and constraints in the Drizzle table MUST match the contract.
+- FK references and `onDelete` behavior MUST match.
+- Index definitions in the contract MUST be reproduced.
+- If the contract uses raw SQL types that don't map cleanly to Drizzle helpers, ask the user before substituting.
+- The generated migration (`pnpm db:generate`) MUST be inspected to confirm it produces the SQL the contract implies; if it diverges, fix the Drizzle definition rather than the SQL.
+
+## Files involved
+
+| Path | Role |
+|---|---|
+| `src/server/db/schema/<name>.ts` | table + relations + types |
+| `src/server/db/schema/_table.ts` | `createTable` — applies `acme_` prefix. **Do not edit.** |
+| `src/server/db/schema/index.ts` | re-export — new tables must be imported here |
+| `src/server/db/utils.ts` | shared `timestamps` helper |
+| `drizzle.config.ts` | drizzle-kit config (`casing: "snake_case"`) |
+
+## Conventions (extracted from `todos.ts`)
+
+1. Use `createTable` from `./_table` — never `pgTable` directly. This applies the `acme_` prefix.
+2. Use the `(d) => ({...})` callback form so column types come from the contextual `d` namespace.
+3. UUID primary keys with `pg_catalog.gen_random_uuid()` default.
+4. Spread `...timestamps` from `../utils`.
+5. Foreign keys: `.references(() => parent.id, { onDelete: "cascade" })` — always specify `onDelete`.
+6. Indexes on FK columns (third arg to `createTable`).
+7. Snake_case casing handled globally — write camelCase in code; drizzle-kit emits snake_case SQL.
+8. Define relations with `relations(table, ({ one, many }) => ({...}))`.
+9. Export `DB_<Name>Type = typeof <table>.$inferSelect` and `DB_<Name>InsertType = typeof <table>.$inferInsert`.
+10. Add to `schema/index.ts`:
+    ```ts
+    import * as myEntity from "./my-entity";
+    export const schema = { ...auth, ...todo, ...myEntity };
+    ```
+
+## Template
+
+[templates/table.ts.tmpl](templates/table.ts.tmpl) — extracted verbatim from `src/server/db/schema/todos.ts`.
+
+## TDD note
+
+Schema changes are validated by:
+1. Drizzle generating the migration without errors (`pnpm db:generate`).
+2. Service-level tests in `gellify-api-domain-service` exercising the new columns.
+
+No standalone "schema test" — the test is the migration + downstream service tests.
+
+## After this skill
+
+Always invoke **`gellify-db-migration`** next.
+
+## Cross-references
+
+- `gellify-db-migration` — generate/apply
+- `gellify-api-domain-service` — queries/mutations using the new columns

--- a/.claude/skills/gellify-db-schema/templates/table.ts.tmpl
+++ b/.claude/skills/gellify-db-schema/templates/table.ts.tmpl
@@ -1,0 +1,48 @@
+// Annotated template — extracted from src/server/db/schema/todos.ts
+// Rename: todoTable / todoRelations / DB_TodoType → your entity.
+
+import { relations, sql } from "drizzle-orm";
+import { index } from "drizzle-orm/pg-core";
+import { timestamps } from "../utils"; // createdAt / updatedAt helpers
+import { createTable } from "./_table"; // applies the `acme_` prefix
+import { user } from "./auth-schema"; // parent FK reference
+
+export const todoTable = createTable(
+  // SQL table name suffix — final name becomes `acme_todo_table`.
+  "todo_table",
+
+  // Column callback — `d` exposes column helpers (d.uuid, d.varchar, d.boolean, ...).
+  (d) => ({
+    id: d
+      .uuid("id")
+      .default(sql`pg_catalog.gen_random_uuid()`)
+      .primaryKey(),
+
+    // createdAt / updatedAt from shared helper.
+    ...timestamps,
+
+    // FK with cascade — always specify onDelete explicitly.
+    userId: d
+      .uuid()
+      .references(() => user.id, { onDelete: "cascade" })
+      .notNull(),
+
+    text: d.varchar({ length: 256 }).notNull(),
+    completed: d.boolean().default(false).notNull(),
+  }),
+
+  // Indexes — array of index() calls. Index every FK column.
+  (t) => [index("user_id_idx").on(t.userId)],
+);
+
+// Relations — separate export, references both ends.
+export const todoRelations = relations(todoTable, ({ one }) => ({
+  user: one(user, {
+    fields: [todoTable.userId],
+    references: [user.id],
+  }),
+}));
+
+// Inferred types — consumed by service / queries / mutations.
+export type DB_TodoType = typeof todoTable.$inferSelect;
+export type DB_TodoInsertType = typeof todoTable.$inferInsert;

--- a/.claude/skills/gellify-db-schema/templates/table.ts.tmpl
+++ b/.claude/skills/gellify-db-schema/templates/table.ts.tmpl
@@ -32,7 +32,8 @@ export const todoTable = createTable(
   }),
 
   // Indexes — array of index() calls. Index every FK column.
-  (t) => [index("user_id_idx").on(t.userId)],
+  // Index names are global in PostgreSQL — prefix with the entity to avoid collisions.
+  (t) => [index("todo_user_id_idx").on(t.userId)],
 );
 
 // Relations — separate export, references both ends.

--- a/.claude/skills/gellify-docs-update/SKILL.md
+++ b/.claude/skills/gellify-docs-update/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: gellify-docs-update
+description: Building block invoked at the end of every gellify-app-maintenance run. Updates project documentation in docs/ for the acme-app and, when the change is architectural, writes an ADR in docs/adr/. Markdown-first. Use directly when the user says "update docs", "document this change", "write an ADR", or after any code change that affects API contracts, domain concepts, or project-wide patterns.
+---
+
+# gellify-docs-update
+
+Final step of every change. Two surfaces: **markdown docs** (always) and **ADR** (sometimes).
+
+## Existing docs layout
+
+```
+docs/
+├── agent/            # Agent-facing guidance (BUILD, CODE_STYLE, PR, SECURITY, TESTING)
+├── auth.md
+├── logs.md
+├── metrics.md
+└── otel.md
+```
+
+No ADR folder exists yet — create `docs/adr/` on first use.
+
+## Decision: ADR or just markdown?
+
+Ask: *"Is this change architectural?"* Yes when any of:
+- new domain concept or entity (e.g., SPID, audit-log)
+- new dependency added or dependency removed
+- change to project-wide pattern (service files → use-cases, error-model change, etc.)
+- contract/versioning decision callers depend on
+- irreversible decision (auth scheme, transport, data model)
+
+No when:
+- bugfix, internal refactor
+- adding a field to an existing entity (unless the field itself is a new concept)
+- validator tweaks that don't change semantics
+- doc-only changes
+
+Default: **no ADR**. Tip toward writing one only when you can name what *future readers* will need to know in 6 months.
+
+## Markdown updates (always)
+
+For API changes, find/create the doc that lives closest to the domain:
+- if a `docs/<domain>.md` exists → update it
+- otherwise create one, linked from the appropriate index
+
+What to include:
+- one-paragraph description of the change
+- new fields / new endpoints / changed behavior
+- breaking notes (if any) — clearly marked
+- examples (curl for REST, tRPC call for tRPC)
+- link to the ADR (if one was written)
+
+For REST, note that **Scalar** at `/api/rest/scalar` is auto-generated from OpenAPI — markdown docs cover the *why*, Scalar covers the *how*.
+
+## ADR — when needed
+
+1. Create `docs/adr/` if missing.
+2. Pick the next number: `NNNN-kebab-title.md` (e.g., `0001-api-versioning-policy.md`).
+3. Use [templates/adr.md.tmpl](templates/adr.md.tmpl) (MADR-lite: Context / Decision / Consequences).
+4. Cross-link: add a link from the relevant `docs/<domain>.md` and from `docs/agent/` if it affects agent guidance.
+
+## After writing
+
+If the change affects how agents should work (e.g., a new convention), also update the relevant file in `docs/agent/` (CODE_STYLE, TESTING, SECURITY, PR, BUILD) — or update `AGENTS.md` / `CLAUDE.md` if cross-cutting.
+
+## Cross-references
+
+- `grill-with-docs` — if the user wants a stress-test of the doc/ADR before finalising
+- `improve-codebase-architecture` — references `docs/adr/` for future improvement runs

--- a/.claude/skills/gellify-docs-update/templates/adr.md.tmpl
+++ b/.claude/skills/gellify-docs-update/templates/adr.md.tmpl
@@ -1,0 +1,38 @@
+# NNNN — <Decision Title>
+
+- **Status**: Proposed | Accepted | Superseded by [NNNN](./NNNN-...md)
+- **Date**: YYYY-MM-DD
+- **Deciders**: <names or roles>
+
+## Context
+
+What is the situation? What forces are at play (technical, business, regulatory, team)? What would happen if we did nothing?
+
+Keep this short — 1–2 paragraphs. Link to issues/PRs/conversations.
+
+## Decision
+
+We will <do X> by <doing Y>.
+
+State the decision plainly, in the active voice. Include the alternatives considered and one-line rejection for each:
+- **Alternative A** — rejected because …
+- **Alternative B** — rejected because …
+
+## Consequences
+
+### Positive
+- …
+
+### Negative / trade-offs
+- …
+
+### Follow-ups
+- [ ] update `docs/<domain>.md`
+- [ ] add deprecation warning to <old surface>
+- [ ] schedule removal for <date>
+
+## References
+
+- Code: `src/...`
+- Related ADRs: [NNNN](./NNNN-...md)
+- External: links to RFCs, vendor docs, etc.


### PR DESCRIPTION
## Summary

Introduces 8 new Claude Code skills under `.claude/skills/` that codify how we build, evolve, and maintain APIs in this repo. The goal is to give every contributor (human or agent) a deterministic, TDD-first workflow that matches the conventions already in `src/server/domains/todo/`, `src/server/api/{trpc,rest}/`, and `src/server/db/schema/`.

## Why

Today, building a new endpoint or evolving an existing one requires holding the whole stack in your head: validator → service (queries/mutations) → tRPC procedure → Hono OpenAPI route → Drizzle table → migration → docs. The conventions exist (todo is the canonical example) but they aren't enforced — and agents in particular tend to invent shapes that drift from the codebase.

These skills solve three problems:

1. **One door for changes.** A single orchestrator (`gellify-app-maintenance`) handles every API / business-logic / DB change. The contributor describes the change in natural language; the skill figures out which layers to touch and dispatches to focused building blocks.
2. **TDD by default.** Every code-emitting skill writes red tests first, waits for the test list to be confirmed, then implements until green — using `bun test` and the patterns from `todo-service.test.ts` / `todos-routes.test.ts`.
3. **Determinism via extracted templates.** Templates aren't invented — they're annotated copies of `todo.ts`, `todos-routes.ts`, `todo-service.ts`, `queries.ts`, `mutations.ts`, and `todos.ts` (schema). Generated code matches existing conventions field-for-field.

## What's included

### Orchestrator
- **`gellify-app-maintenance`** — single entry point. Intake → plan → confirmation gate → TDD dispatch. Routes any of: new endpoint, edit existing logic, rename/deprecate/version/break.

### Building blocks (invoked by the orchestrator)
- **`gellify-api-trpc-procedure`** — adds/edits tRPC procedures with `wideEvent` enrichment.
- **`gellify-api-rest-route`** — adds/edits Hono OpenAPI routes with the full 200/401/403/404/422/500 response set and `withRequiredPermissions`.
- **`gellify-api-domain-service`** — service / queries / mutations files following the `(db, input, userId)` signature convention.
- **`gellify-db-schema`** — Drizzle tables using `createTable` (so the `acme_` prefix and snake_case casing stay consistent).
- **`gellify-db-migration`** — drizzle-kit wrapper with a destructive-change review protocol.
- **`gellify-docs-update`** — markdown-first doc updates + MADR-lite ADR template; creates `docs/adr/` on first use.

### Standalone
- **`gellify-api-contract`** — turns an issue (Linear / GitHub / Jira / pasted text) into an OpenAPI 3.1 spec under `docs/api/contracts/`. Resolves resource names against `docs/GLOSSARY.md` (creates it if missing) and the existing codebase before inventing new names. Embeds a concise REST design guide as `REFERENCE.md` (RFC 9110 + Stripe / Zalando / Microsoft conventions). Explicitly excluded from the maintenance workflow — its only contact point with implementation is the contract YAML and the glossary.

## How they cooperate with existing skills

The skills delegate to skills already present in this repo and `node_modules`:

- `tdd` for the red-green-refactor loop
- `engineering:write-tests` for test conventions
- `logging-best-practices` for `wideEvent` shape
- `better-auth-best-practices` for permissions
- `next-best-practices` for App Router concerns
- `simplify` for post-green cleanup
- `node_modules/@trpc/server/skills/{server-setup,auth,middlewares,validators}` for tRPC internals

## Contract-as-input

Every skill accepts an authoritative contract (Zod, OpenAPI fragment, tRPC signature, SQL DDL, Drizzle snippet, TS interface). When provided, validators / column types / response shapes must match field-for-field — the skill asks before inventing anything not in the contract.

## Worked examples (also in DISPATCH.md)

- *"create-user API: check CF uniqueness, add SPID relation"* → touches schema + migration + service + validator + router + docs + **ADR** (new domain concept).
- *"read-user API: only return active users"* → touches service only (one query change) + docs. No ADR.

Same entry skill, very different dispatch.

## Test plan

- [ ] Open a small test request like *"add a 'priority' field to todos"* — verify the orchestrator picks `gellify-app-maintenance`, proposes a layer plan + test list, waits for confirmation.
- [ ] Verify it dispatches in order: `gellify-db-schema` → `gellify-db-migration` → `gellify-api-domain-service` → router skills → `gellify-docs-update`.
- [ ] Run `pnpm test`, `pnpm lint`, `pnpm typecheck` after each layer.
- [ ] For `gellify-api-contract`: paste a fake issue body and verify it produces a YAML under `docs/api/contracts/` and updates `docs/GLOSSARY.md` — without writing any code.
- [ ] Verify `gellify-app-maintenance` does **not** trigger on a pure contract-design request, and `gellify-api-contract` does **not** trigger on implementation requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Added comprehensive skill guides and workflow templates for API development, including contract design, database schema management, REST routes, and tRPC procedures.
  - Added maintenance playbooks and architectural decision record templates for managing application changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GELLIFY/acme-app/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->