### PR TITLE
fix(ci): source production DATABASE_URL from Vercel, not a GH secret

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,5 +1,9 @@
 name: Deploy Production
 
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
 on:
   push:
     branches:
@@ -29,9 +33,8 @@ jobs:
 
       - name: Apply Migrations
         run: |
-          touch .env
+          pnpm dlx vercel env pull .env --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           echo SKIP_ENV_VALIDATION=1 >> .env
-          echo DATABASE_URL=${{ secrets.DATABASE_URL }} >> .env
           pnpm run db:migrate
 
   deploy_production:


### PR DESCRIPTION
## Summary
- `secrets.DATABASE_URL` was removed from repo secrets, breaking `run_migrations` on every push to `main` since it was the last place still reading that secret directly (preview already moved to sourcing its DB URL from Vercel in #152).
- `run_migrations` now pulls `DATABASE_URL` from Vercel's Production environment via `vercel env pull`, same pattern already validated on preview. Confirmed the value isn't marked `sensitive` in Vercel, so it's readable via CLI pull.
- Adds `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` at the workflow level (same as preview), required for non-interactive `vercel` CLI usage in this project.

## Test plan
- [ ] Merge and confirm `Run Migrations` succeeds on the next push to `main`
- [ ] Confirm `Deploy Production` proceeds afterward (currently skipped because migrations fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)